### PR TITLE
Use shared_ptr for all types.

### DIFF
--- a/example-osx/emptyExample.xcodeproj/project.pbxproj
+++ b/example-osx/emptyExample.xcodeproj/project.pbxproj
@@ -16,7 +16,6 @@
 		99CF9A3819C1DD2600846E29 /* tinyxmlerror.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 99CF9A3219C1DD2600846E29 /* tinyxmlerror.cpp */; };
 		99CF9A3919C1DD2600846E29 /* tinyxmlparser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 99CF9A3319C1DD2600846E29 /* tinyxmlparser.cpp */; };
 		99CF9A3A19C1DD2600846E29 /* ofxXmlSettings.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 99CF9A3519C1DD2600846E29 /* ofxXmlSettings.cpp */; };
-		BBAB23CB13894F3D00AA2426 /* GLUT.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = BBAB23BE13894E4700AA2426 /* GLUT.framework */; };
 		E4328149138ABC9F0047C5CB /* openFrameworksDebug.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E4328148138ABC890047C5CB /* openFrameworksDebug.a */; };
 		E45BE97B0E8CC7DD009D7055 /* AGL.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E45BE9710E8CC7DD009D7055 /* AGL.framework */; };
 		E45BE97C0E8CC7DD009D7055 /* ApplicationServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E45BE9720E8CC7DD009D7055 /* ApplicationServices.framework */; };
@@ -31,7 +30,6 @@
 		E4C2424710CC5A17004149E2 /* AppKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E4C2424410CC5A17004149E2 /* AppKit.framework */; };
 		E4C2424810CC5A17004149E2 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E4C2424510CC5A17004149E2 /* Cocoa.framework */; };
 		E4C2424910CC5A17004149E2 /* IOKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E4C2424610CC5A17004149E2 /* IOKit.framework */; };
-		E4EB6799138ADC1D00A09F29 /* GLUT.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BBAB23BE13894E4700AA2426 /* GLUT.framework */; };
 		E7E077E515D3B63C0020DFD4 /* CoreVideo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E7E077E415D3B63C0020DFD4 /* CoreVideo.framework */; };
 		E7E077E815D3B6510020DFD4 /* QTKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E7E077E715D3B6510020DFD4 /* QTKit.framework */; };
 		E7F985F815E0DEA3003869B5 /* Accelerate.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E7F985F515E0DE99003869B5 /* Accelerate.framework */; };
@@ -61,7 +59,6 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				BBAB23CB13894F3D00AA2426 /* GLUT.framework in CopyFiles */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -87,7 +84,6 @@
 		99CF9A3319C1DD2600846E29 /* tinyxmlparser.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = tinyxmlparser.cpp; sourceTree = "<group>"; };
 		99CF9A3519C1DD2600846E29 /* ofxXmlSettings.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ofxXmlSettings.cpp; sourceTree = "<group>"; };
 		99CF9A3619C1DD2600846E29 /* ofxXmlSettings.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofxXmlSettings.h; sourceTree = "<group>"; };
-		BBAB23BE13894E4700AA2426 /* GLUT.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = GLUT.framework; path = ../../../libs/glut/lib/osx/GLUT.framework; sourceTree = "<group>"; };
 		E4328143138ABC890047C5CB /* openFrameworksLib.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = openFrameworksLib.xcodeproj; path = ../../../libs/openFrameworksCompiled/project/osx/openFrameworksLib.xcodeproj; sourceTree = SOURCE_ROOT; };
 		E45BE9710E8CC7DD009D7055 /* AGL.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AGL.framework; path = /System/Library/Frameworks/AGL.framework; sourceTree = "<absolute>"; };
 		E45BE9720E8CC7DD009D7055 /* ApplicationServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ApplicationServices.framework; path = /System/Library/Frameworks/ApplicationServices.framework; sourceTree = "<absolute>"; };
@@ -119,7 +115,6 @@
 			files = (
 				E7F985F815E0DEA3003869B5 /* Accelerate.framework in Frameworks */,
 				E7E077E815D3B6510020DFD4 /* QTKit.framework in Frameworks */,
-				E4EB6799138ADC1D00A09F29 /* GLUT.framework in Frameworks */,
 				E4328149138ABC9F0047C5CB /* openFrameworksDebug.a in Frameworks */,
 				E45BE97B0E8CC7DD009D7055 /* AGL.framework in Frameworks */,
 				E45BE97C0E8CC7DD009D7055 /* ApplicationServices.framework in Frameworks */,
@@ -220,14 +215,6 @@
 			name = "system frameworks";
 			sourceTree = "<group>";
 		};
-		BBAB23CA13894EDB00AA2426 /* 3rd party frameworks */ = {
-			isa = PBXGroup;
-			children = (
-				BBAB23BE13894E4700AA2426 /* GLUT.framework */,
-			);
-			name = "3rd party frameworks";
-			sourceTree = "<group>";
-		};
 		E4328144138ABC890047C5CB /* Products */ = {
 			isa = PBXGroup;
 			children = (
@@ -239,7 +226,6 @@
 		E45BE5980E8CC70C009D7055 /* frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				BBAB23CA13894EDB00AA2426 /* 3rd party frameworks */,
 				BBAB23C913894ECA00AA2426 /* system frameworks */,
 			);
 			name = frameworks;

--- a/example-osx/src/ofApp.cpp
+++ b/example-osx/src/ofApp.cpp
@@ -2,7 +2,7 @@
 
 //--------------------------------------------------------------
 void ofApp::setup(){
-    tpRotatedTrim = new ofxTexturePacker();
+    tpRotatedTrim = ofxTexturePackerPtr(new ofxTexturePacker());
     tpRotatedTrim->load("texture/rotated-trim.xml");
     tpRotatedTrim->setDebugMode(true);
     sprite = tpRotatedTrim->getSprite("Box2.png");
@@ -17,7 +17,7 @@ void ofApp::setup(){
     }
     
     //------------------
-    tpRotatedNoTrim = new ofxTexturePacker();
+    tpRotatedNoTrim = ofxTexturePackerPtr(new ofxTexturePacker());
     tpRotatedNoTrim->load("texture/rotated-trim.xml");
     tpRotatedNoTrim->setDebugMode(true);
     tpRotatedNoTrimAnimation = tpRotatedNoTrim->getAnimatedSprite("CapGuyWalk");
@@ -28,7 +28,7 @@ void ofApp::setup(){
         ofLog(OF_LOG_FATAL_ERROR, "ofApp::setup():: Could not load animated sprite");
     }
     
-    tpTrim = new ofxTexturePacker();
+    tpTrim = ofxTexturePackerPtr(new ofxTexturePacker());
     tpTrim->load("texture/trim.xml");
     tpTrimAnimation = tpTrim->getAnimatedSprite("CapGuyWalk");
     tpTrim->setDebugMode(true);
@@ -39,7 +39,7 @@ void ofApp::setup(){
         ofLog(OF_LOG_FATAL_ERROR, "ofApp::setup():: Could not load animated sprite");
     }
     
-    tpNoTrim = new ofxTexturePacker();
+    tpNoTrim = ofxTexturePackerPtr(new ofxTexturePacker());
     tpNoTrim->load("texture/notrim.xml");
     tpNoTrim->setDebugMode(false);
     tpNoTrimAnimation = tpNoTrim->getAnimatedSprite("CapGuyWalk");
@@ -54,22 +54,10 @@ void ofApp::setup(){
 
 void ofApp::exit() {
     
-    if(tpRotatedTrim) {
-        delete tpRotatedTrim;
-        tpRotatedTrim = NULL;
-    }
-    if(tpRotatedNoTrim) {
-        delete tpRotatedNoTrim;
-        tpRotatedNoTrim = NULL;
-    }
-    if(tpNoTrim) {
-        delete tpNoTrim;
-        tpNoTrim = NULL;
-    }
-    if(tpTrim) {
-        delete tpTrim;
-        tpTrim = NULL;
-    }
+    tpRotatedTrim.reset();
+    tpRotatedNoTrim.reset();
+    tpNoTrim.reset();
+    tpTrim.reset();
 }
 
 //--------------------------------------------------------------

--- a/example-osx/src/ofApp.h
+++ b/example-osx/src/ofApp.h
@@ -22,17 +22,17 @@ class ofApp : public ofBaseApp{
 		void dragEvent(ofDragInfo dragInfo);
 		void gotMessage(ofMessage msg);
     
-        ofxTexturePacker * tpRotatedTrim;
-        ofxTexturePacker * tpRotatedNoTrim;
-        ofxTexturePacker * tpNoTrim;
-        ofxTexturePacker * tpTrim;
+        ofxTexturePackerPtr tpRotatedTrim;
+        ofxTexturePackerPtr tpRotatedNoTrim;
+        ofxTexturePackerPtr tpNoTrim;
+        ofxTexturePackerPtr tpTrim;
     
     
-        ofxTPSprite * sprite;
+        ofxTPSpritePtr sprite;
     
-        ofxTPAnimatedSprite * tpRotatedTrimAnimation;
-        ofxTPAnimatedSprite * tpRotatedNoTrimAnimation;
-        ofxTPAnimatedSprite * tpTrimAnimation;
-        ofxTPAnimatedSprite * tpNoTrimAnimation;
+        ofxTPAnimatedSpritePtr tpRotatedTrimAnimation;
+        ofxTPAnimatedSpritePtr tpRotatedNoTrimAnimation;
+        ofxTPAnimatedSpritePtr tpTrimAnimation;
+        ofxTPAnimatedSpritePtr tpNoTrimAnimation;
 		
 };

--- a/src/ofxTPAnimatedSprite.cpp
+++ b/src/ofxTPAnimatedSprite.cpp
@@ -44,18 +44,18 @@ void ofxTPAnimatedSprite::update() {
     }
 }
 
-void ofxTPAnimatedSprite::addSprite(ofxTPSprite * sprite) {
+void ofxTPAnimatedSprite::addSprite(ofxTPSpritePtr sprite) {
     frames.push_back(sprite);
     frameLast = frames.size()-1;
     framesTotal = frames.size();
 }
 
-ofxTPSprite* ofxTPAnimatedSprite::getCurrentSprite() {
+ofxTPSpritePtr ofxTPAnimatedSprite::getCurrentSprite() {
     unsigned int currentFrameIndex = getCurrentFrame();
     unsigned int allFramesIndex = frames.size();
     if(frames.size() == 0 || currentFrameIndex > allFramesIndex) {
         ofLog(OF_LOG_ERROR, "ofxTPAnimatedSprite::getCurrentSprite Current Frame is out of index for loaded AnimatedSprite");
-        return NULL;
+        return ofxTPSpritePtr();
     } else {
         return frames[currentFrameIndex];
     }
@@ -187,12 +187,12 @@ void ofxTPAnimatedSprite::previousFrame() {
     setFrame(index);
 }
 
-void ofxTPAnimatedSprite::setTexture(ofTexture* tex){
+void ofxTPAnimatedSprite::setTexture(shared_ptr<ofTexture> tex){
     if(frames.size() != 0) {
         unsigned int frameSize = frames.size()-1;
         for(unsigned int i=0; i<=frameSize; i++) {
-            ofxTPSprite* sprite = frames[i];
-            if(sprite != NULL) {
+            ofxTPSpritePtr sprite = frames[i];
+            if(sprite) {
                 sprite->setTexture(tex);
             }
         }
@@ -204,8 +204,8 @@ void ofxTPAnimatedSprite::setDebugMode(bool debugMode) {
     if(frames.size() != 0) {
         unsigned int frameSize = frames.size()-1;
         for(unsigned int i=0; i<=frameSize; i++) {
-            ofxTPSprite* sprite = frames[i];
-            if(sprite != NULL) {
+            ofxTPSpritePtr sprite = frames[i];
+            if(sprite) {
                 sprite->setDebugMode(debugMode);
             }
         }

--- a/src/ofxTPAnimatedSprite.h
+++ b/src/ofxTPAnimatedSprite.h
@@ -10,6 +10,9 @@
 #include "ofxTPTypes.h"
 #include "ofxTPSprite.h"
 
+class ofxTPAnimatedSprite;
+typedef shared_ptr<ofxTPAnimatedSprite> ofxTPAnimatedSpritePtr;
+
 class ofxTPAnimatedSprite : public ofxTPSpriteCore {
 public:
     ofxTPAnimatedSprite();
@@ -20,8 +23,8 @@ public:
     void setName(const string& theName);
     const string& getName() const;
     
-    void addSprite(ofxTPSprite * sprite);
-    ofxTPSprite* getCurrentSprite();
+    void addSprite(ofxTPSpritePtr sprite);
+    ofxTPSpritePtr getCurrentSprite();
     
     
     void play();
@@ -53,7 +56,7 @@ public:
     float getWidth();
     float getHeight();
     
-    void setTexture(ofTexture* tex);
+    void setTexture(shared_ptr<ofTexture> tex);
     
     void setDebugMode(bool debugMode);
     
@@ -77,7 +80,7 @@ protected:
     bool bNewFrame;
     
     //! frame is a vector of all ofxTPSprites for this Animated Sprite Sequence. Memory managed by ofxTexturePacker.
-    vector<ofxTPSprite*> frames;
+    vector<ofxTPSpritePtr> frames;
 };
 //------------
 inline void ofxTPAnimatedSprite::setName(const string& theName) {

--- a/src/ofxTPLoader.cpp
+++ b/src/ofxTPLoader.cpp
@@ -6,78 +6,69 @@
 
 #include "ofxTPLoader.h"
 
-ofxTPLoader::ofxTPLoader() : XML(new ofxXmlSettings()), textureAtlas(new ofxTPTextureAtlas()), fileXMLPath("") {
+ofxTPLoader::ofxTPLoader() :
+    textureAtlas(new ofxTPTextureAtlas()),
+    fileXMLPath("") {
 }
 
 ofxTPLoader::~ofxTPLoader() {
-    if(textureAtlas) {
-        delete textureAtlas;
-        textureAtlas = NULL;
-    }
-    if(XML) {
-        delete XML;
-        XML = NULL;
-    }
 }
 
-vector<ofxTPSpriteData*> ofxTPLoader::load(const string fileName) {
+vector<ofxTPSpriteDataPtr> ofxTPLoader::load(const string fileName) {
+    ofxXmlSettings XML;
     fileXMLPath = fileName;
-    if( XML->loadFile(fileXMLPath) ){
+    if( XML.loadFile(fileXMLPath) ){
         ofLog(OF_LOG_VERBOSE, fileXMLPath+ " loaded!");
     } else{
         ofLog(OF_LOG_ERROR, " unable to load " + fileXMLPath + " check data/ folder");
     }
     
-    unsigned int isTextureAtlas = XML->getNumTags("TextureAtlas");
-    vector<ofxTPSpriteData*> sprites;
+    unsigned int isTextureAtlas = XML.getNumTags("TextureAtlas");
+    vector<ofxTPSpriteDataPtr> sprites;
     
     if(isTextureAtlas != 0) {
-        string a = XML->getAttribute("TextureAtlas", "imagePath", "");
+        string a = XML.getAttribute("TextureAtlas", "imagePath", "");
         vector<string> names;
-        XML->getAttributeNames("TextureAtlas", names);
+        XML.getAttributeNames("TextureAtlas", names);
         if(names.size() != 0) {
             for(unsigned int i = 0; i<=names.size()-1; i++) {
                 ofLog(OF_LOG_VERBOSE, names[i]);
             }
         }
         
-        textureAtlas->setImagePath(XML->getAttribute("TextureAtlas", "imagePath", ""));
-        textureAtlas->setWidth(XML->getAttribute("TextureAtlas", "width", 0));
-        textureAtlas->setHeight(XML->getAttribute("TextureAtlas", "height", 0));
+        textureAtlas->setImagePath(XML.getAttribute("TextureAtlas", "imagePath", ""));
+        textureAtlas->setWidth(XML.getAttribute("TextureAtlas", "width", 0));
+        textureAtlas->setHeight(XML.getAttribute("TextureAtlas", "height", 0));
         
-        XML->pushTag("TextureAtlas", 0);
-        unsigned int numberOfSprites = XML->getNumTags("sprite");
+        XML.pushTag("TextureAtlas", 0);
+        unsigned int numberOfSprites = XML.getNumTags("sprite");
         if(numberOfSprites > 0){
             vector<string> names;
-            XML->getAttributeNames("sprite", names);
+            XML.getAttributeNames("sprite", names);
             if(names.size() != 0) {
                 for(unsigned int i = 0; i<=names.size()-1; i++) {
                     ofLog(OF_LOG_VERBOSE, names[i]);
                 }
             }
             for(int i = 0; i < numberOfSprites; i++){
-                ofxTPSpriteData * sprite = new ofxTPSpriteData();
-                sprite->setName(XML->getAttribute("sprite", "n", "", i));
-                sprite->setX(XML->getAttribute("sprite", "x", 0, i));
-                sprite->setY(XML->getAttribute("sprite", "y", 0, i));
-                sprite->setW(XML->getAttribute("sprite", "w", 0, i));
-                sprite->setH(XML->getAttribute("sprite", "h", 0, i));
-                sprite->setPX(XML->getAttribute("sprite", "pX", 0, i));
-                sprite->setPY(XML->getAttribute("sprite", "pY", 0, i));
-                sprite->setOffsetX(XML->getAttribute("sprite", "oX", 0, i));
-                sprite->setOffsetY(XML->getAttribute("sprite", "oY", 0, i));
-                sprite->setOffsetWidth(XML->getAttribute("sprite", "oW",  sprite->getW(), i));
-                sprite->setOffsetHeight(XML->getAttribute("sprite", "oH", sprite->getH(), i));
-                sprite->determineRotated(XML->getAttribute("sprite", "r", "", i));
+                ofxTPSpriteDataPtr sprite = ofxTPSpriteDataPtr(new ofxTPSpriteData());
+                sprite->setName(XML.getAttribute("sprite", "n", "", i));
+                sprite->setX(XML.getAttribute("sprite", "x", 0, i));
+                sprite->setY(XML.getAttribute("sprite", "y", 0, i));
+                sprite->setW(XML.getAttribute("sprite", "w", 0, i));
+                sprite->setH(XML.getAttribute("sprite", "h", 0, i));
+                sprite->setPX(XML.getAttribute("sprite", "pX", 0, i));
+                sprite->setPY(XML.getAttribute("sprite", "pY", 0, i));
+                sprite->setOffsetX(XML.getAttribute("sprite", "oX", 0, i));
+                sprite->setOffsetY(XML.getAttribute("sprite", "oY", 0, i));
+                sprite->setOffsetWidth(XML.getAttribute("sprite", "oW",  sprite->getW(), i));
+                sprite->setOffsetHeight(XML.getAttribute("sprite", "oH", sprite->getH(), i));
+                sprite->determineRotated(XML.getAttribute("sprite", "r", "", i));
                 sprite->setup();
                 sprites.push_back(sprite);
             }
         }
-        XML->popTag();
+        XML.popTag();
     }
     return sprites;
-}
-
-void ofxTPLoader::clearXML() {
-    XML->clear();
 }

--- a/src/ofxTPLoader.h
+++ b/src/ofxTPLoader.h
@@ -10,6 +10,8 @@
 #include "ofxTPSpriteData.h"
 #include "ofxTPTextureAtlas.h"
 
+class ofxTPLoader;
+typedef shared_ptr<ofxTPLoader> ofxTPLoaderPtr;
 
 class ofxTPLoader {
 public:
@@ -17,17 +19,13 @@ public:
     ofxTPLoader();
     ~ofxTPLoader();
     
-    vector<ofxTPSpriteData*> load(const string fileName);
+    vector<ofxTPSpriteDataPtr> load(const string fileName);
     const string& getImagePath() const;
     const string& getFileXMLPath() const;
-    void clearXML();
     
-
-    
-    ofxTPTextureAtlas * textureAtlas;
+    ofxTPTextureAtlasPtr textureAtlas;
     
 protected:
-    ofxXmlSettings * XML;
     
     string fileXMLPath;
     bool bLoaded;

--- a/src/ofxTPSprite.cpp
+++ b/src/ofxTPSprite.cpp
@@ -5,9 +5,11 @@
 // ------------------------------------------------------------------
 #include "ofxTPSprite.h"
 
-ofxTPSprite::ofxTPSprite(ofxTPSpriteData* theData) {
-    data = theData;
+ofxTPSprite::ofxTPSprite(ofxTPSpriteDataPtr theData) :
+    data(theData)
+{
 }
+
 float ofxTPSprite::getWidth(){
     return data->getW();
 }

--- a/src/ofxTPSprite.cpp
+++ b/src/ofxTPSprite.cpp
@@ -35,7 +35,7 @@ void ofxTPSprite::draw(int x, int y) {
                 ofPushStyle();
                 ofSetColor(0, 255, 0, 128);
                 ofNoFill();
-                ofRect(x-data->getOffsetY(), y-data->getOffsetX(), data->getOffsetHeight(), data->getOffsetWidth());
+                ofDrawRectangle(x-data->getOffsetY(), y-data->getOffsetX(), data->getOffsetHeight(), data->getOffsetWidth());
                 ofPopStyle();
             }
         
@@ -48,7 +48,7 @@ void ofxTPSprite::draw(int x, int y) {
         if(!data->isRotated()){
             ofPushStyle();
             ofNoFill();
-            ofRect(x-data->getOffsetX(), y-data->getOffsetY(), data->getOffsetWidth(), data->getOffsetHeight());
+            ofDrawRectangle(x-data->getOffsetX(), y-data->getOffsetY(), data->getOffsetWidth(), data->getOffsetHeight());
             ofPopStyle();
         }
     }

--- a/src/ofxTPSprite.h
+++ b/src/ofxTPSprite.h
@@ -18,7 +18,7 @@ public:
     const string& getName() const;
     ofxTPSpriteData* getData();
     float getWidth();
-    void setDebugMode(const bool debugMode);
+    void setDebugMode(bool debugMode);
 protected:
     ofxTPSpriteData* data;
 };

--- a/src/ofxTPSprite.h
+++ b/src/ofxTPSprite.h
@@ -8,31 +8,33 @@
 #include "ofxTPSpriteCore.h"
 #include "ofxTPSpriteData.h"
 
+class ofxTPSprite;
+typedef shared_ptr<ofxTPSprite> ofxTPSpritePtr;
+
 //------------------------------------------------------
 class ofxTPSprite : public ofxTPSpriteCore {
 public:
-    ofxTPSprite(ofxTPSpriteData* theData);
+    ofxTPSprite(ofxTPSpriteDataPtr data);
     
     void draw(int x, int y);
     
     const string& getName() const;
-    ofxTPSpriteData* getData();
+    ofxTPSpriteDataPtr getData();
     float getWidth();
     void setDebugMode(bool debugMode);
 protected:
-    ofxTPSpriteData* data;
+    ofxTPSpriteDataPtr data;
 };
 //----------
 inline const string& ofxTPSprite::getName() const {
     return data->getName();
 }
 //----------
-inline ofxTPSpriteData* ofxTPSprite::getData() {
+inline ofxTPSpriteDataPtr ofxTPSprite::getData() {
     return data;
 }
 
 inline void ofxTPSprite::setDebugMode(const bool debugMode) {
-    if(data != NULL) {
+    if (data)
         data->setDebugMode(debugMode);
-    }
 }

--- a/src/ofxTPSpriteCore.h
+++ b/src/ofxTPSpriteCore.h
@@ -12,13 +12,13 @@
 class ofxTPSpriteCore {
 public:
     
-    ofxTPSpriteCore() : texture(NULL), type(OFX_TP_SPRITE), name("") { }
+    ofxTPSpriteCore() : texture(), type(OFX_TP_SPRITE), name("") { }
     virtual void draw(int x, int y) {}
     virtual void update(int x, int y) {}
     
     bool compareName(const string & otherName) const;
     
-    void setTexture(ofTexture* tex);
+    void setTexture(shared_ptr<ofTexture> tex);
     virtual void setName(const string& sName);
     
     virtual void setDebugMode(bool debugMode){};
@@ -26,7 +26,7 @@ public:
     virtual const string& getName() const;
     ofxTPSpriteType getType() const;
 protected:
-    ofTexture * texture;
+    shared_ptr<ofTexture> texture;
     ofxTPSpriteType type;
     string name;
 };
@@ -35,7 +35,7 @@ protected:
 inline bool ofxTPSpriteCore::compareName(const string & otherName) const { return (getName() == otherName); }
 //-------
 inline void ofxTPSpriteCore::setName(const string& sName) { name = sName; }
-inline void ofxTPSpriteCore::setTexture(ofTexture* tex) { texture = tex; }
+inline void ofxTPSpriteCore::setTexture(shared_ptr<ofTexture> tex) { texture = tex; }
 //------- Getters
 inline const string& ofxTPSpriteCore::getName() const { return name; }
 inline ofxTPSpriteType ofxTPSpriteCore::getType() const { return type; }

--- a/src/ofxTPSpriteCore.h
+++ b/src/ofxTPSpriteCore.h
@@ -21,7 +21,7 @@ public:
     void setTexture(ofTexture* tex);
     virtual void setName(const string& sName);
     
-    virtual void setDebugMode(const bool debugMode){};
+    virtual void setDebugMode(bool debugMode){};
     
     virtual const string& getName() const;
     ofxTPSpriteType getType() const;

--- a/src/ofxTPSpriteData.h
+++ b/src/ofxTPSpriteData.h
@@ -14,6 +14,9 @@
 //#include "regex.h"  // posix
 #include <Poco/RegularExpression.h>
 
+class ofxTPSpriteData;
+typedef shared_ptr<ofxTPSpriteData> ofxTPSpriteDataPtr;
+
 class ofxTPSpriteData {
 public:
     ofxTPSpriteData();
@@ -26,19 +29,19 @@ public:
     void determineRotated(const string & isRotated);
     void extractFrame();
     
-    void setX(const int& sX);
-    void setY(const int& sY);
-    void setW(const int& sWidth);
-    void setH(const int& sHeight);
-    void setPX(const float& sPX);
-    void setPY(const float& sPY);
-    void setWidth(const int& sWidth);
-    void setHeight(const int& sHeight);
-    void setOffsetX(const int& soX);
-    void setOffsetY(const int& soY);
-    void setOffsetWidth(const int& soWidth);
-    void setOffsetHeight(const int& soHeight);
-    void setDebugMode(const bool debug);
+    void setX(int sX);
+    void setY(int sY);
+    void setW(int sWidth);
+    void setH(int sHeight);
+    void setPX(float sPX);
+    void setPY(float sPY);
+    void setWidth(int sWidth);
+    void setHeight(int sHeight);
+    void setOffsetX(int soX);
+    void setOffsetY(int soY);
+    void setOffsetWidth(int soWidth);
+    void setOffsetHeight(int soHeight);
+    void setDebugMode(bool debug);
     
     const string& getName() const;
     const string& getAnimationName() const;
@@ -97,19 +100,19 @@ inline void ofxTPSpriteData::setName(const string& theName) {
 }
 //--------- Setters
 inline void ofxTPSpriteData::setAnimationName(const string& sAnimationName) { animationName = sAnimationName; }
-inline void ofxTPSpriteData::setX(const int& sX) { x = sX; }
-inline void ofxTPSpriteData::setY(const int& sY) { y = sY; }
-inline void ofxTPSpriteData::setW(const int& sWidth) { w = sWidth; }
-inline void ofxTPSpriteData::setH(const int& sHeight) { h = sHeight; }
-inline void ofxTPSpriteData::setPX(const float& sPX) { pX = sPX; }
-inline void ofxTPSpriteData::setPY(const float& sPY) { pY = sPY; }
-inline void ofxTPSpriteData::setWidth(const int& sWidth) { w = sWidth; }
-inline void ofxTPSpriteData::setHeight(const int& sHeight) { h = sHeight; }
-inline void ofxTPSpriteData::setOffsetX(const int& soX) { oX = soX; }
-inline void ofxTPSpriteData::setOffsetY(const int& soY) { oY = soY; }
-inline void ofxTPSpriteData::setOffsetWidth(const int& soWidth) { oW = soWidth; }
-inline void ofxTPSpriteData::setOffsetHeight(const int& soHeight) { oH = soHeight; }
-inline void ofxTPSpriteData::setDebugMode(const bool debug) { bDebugMode = debug; }
+inline void ofxTPSpriteData::setX(int sX) { x = sX; }
+inline void ofxTPSpriteData::setY(int sY) { y = sY; }
+inline void ofxTPSpriteData::setW(int sWidth) { w = sWidth; }
+inline void ofxTPSpriteData::setH(int sHeight) { h = sHeight; }
+inline void ofxTPSpriteData::setPX(float sPX) { pX = sPX; }
+inline void ofxTPSpriteData::setPY(float sPY) { pY = sPY; }
+inline void ofxTPSpriteData::setWidth(int sWidth) { w = sWidth; }
+inline void ofxTPSpriteData::setHeight(int sHeight) { h = sHeight; }
+inline void ofxTPSpriteData::setOffsetX(int soX) { oX = soX; }
+inline void ofxTPSpriteData::setOffsetY(int soY) { oY = soY; }
+inline void ofxTPSpriteData::setOffsetWidth(int soWidth) { oW = soWidth; }
+inline void ofxTPSpriteData::setOffsetHeight(int soHeight) { oH = soHeight; }
+inline void ofxTPSpriteData::setDebugMode(bool debug) { bDebugMode = debug; }
 //--------- Getters
 inline const string& ofxTPSpriteData::getName() const { return name; }
 inline const string& ofxTPSpriteData::getAnimationName() const { return animationName; }

--- a/src/ofxTPTextureAtlas.h
+++ b/src/ofxTPTextureAtlas.h
@@ -7,6 +7,9 @@
 #pragma once
 #include "ofMain.h"
 
+class ofxTPTextureAtlas;
+typedef shared_ptr<ofxTPTextureAtlas> ofxTPTextureAtlasPtr;
+
 class ofxTPTextureAtlas {
 public:
     ofxTPTextureAtlas() : imagePath(""), w(0), h(0) {

--- a/src/ofxTexturePacker.h
+++ b/src/ofxTexturePacker.h
@@ -37,6 +37,9 @@
 
 //--------------------------------------------------
 
+class ofxTexturePacker;
+typedef shared_ptr<ofxTexturePacker> ofxTexturePackerPtr;
+
 class ofxTexturePacker {
 public:
     ofxTexturePacker();
@@ -48,21 +51,21 @@ public:
     vector<string> getSpriteNames();
     vector<string> getAnimationNames();
     
-    ofxTPSprite* getSprite(const string& spriteName);
-    ofxTPAnimatedSprite* getAnimatedSprite(const string& spriteName);
+    ofxTPSpritePtr getSprite(const string& spriteName);
+    ofxTPAnimatedSpritePtr getAnimatedSprite(const string& spriteName);
     
     void setDebugMode(bool debugMode);
     
-    ofTexture* getTexture();
+    shared_ptr<ofTexture> getTexture();
     const string getTextureFilePath() const;
-    void setTexture(ofTexture* newTexture);
+    void setTexture(shared_ptr<ofTexture> newTexture);
     
 protected:
 
-    vector<ofxTPSprite*> sprites;
-    vector<ofxTPAnimatedSprite*> animatedSprites;
-    ofTexture* texture;
-    ofxTPLoader* loader;
+    vector<ofxTPSpritePtr> sprites;
+    vector<ofxTPAnimatedSpritePtr> animatedSprites;
+    shared_ptr<ofTexture> texture;
+    ofxTPLoaderPtr loader;
     bool bDebugMode;
     
     void createLoader();
@@ -70,7 +73,7 @@ protected:
     void removeTexture();
 };
 
-inline ofTexture* ofxTexturePacker::getTexture() {
+inline shared_ptr<ofTexture> ofxTexturePacker::getTexture() {
     return texture;
 }
 


### PR DESCRIPTION
- All raw pointers changed to use shared_ptr.
- Fixes some deprecations and compiler warnings.
- Small change to vector iteration code.
- Change setters to use primitive type pass-by-value rather than pass-by-reference.