### PR TITLE
pivot works

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,5 +50,25 @@ ofxTPSprite * normal = texturePacker.getSprite("images/normal.png");
 
 ```
 
+How to load an animated sprite
+```
+ofxTexturePackerPtr texturepacker;
+ofxTPAnimatedSpritePtr spaceship_sprite;
+
+texturepacker = ofxTexturePackerPtr(new ofxTexturePacker());
+texturepacker->load("spaceship/spaceship.xml");
+spaceship_sprite = texturepacker->getAnimatedSprite("spaceship");
+spaceship_sprite->play();
+```
+
+Don't forget to `update()` your sprite.
+
+## Notes
+
+* ofxTexturePacker loads the png image designated by the xml file using a path relative to the xml file's location.
+* getAnimationNames requires that you name your sprites with a common prefix
+* disable trimming if you set the pivot
+
+
 Still a work in progress. Will be maintained.
 

--- a/src/ofxTPLoader.cpp
+++ b/src/ofxTPLoader.cpp
@@ -52,13 +52,14 @@ vector<ofxTPSpriteDataPtr> ofxTPLoader::load(const string fileName) {
             }
             for(int i = 0; i < numberOfSprites; i++){
                 ofxTPSpriteDataPtr sprite = ofxTPSpriteDataPtr(new ofxTPSpriteData());
+                string n = XML.getAttribute("sprite", "n", "", i);
                 sprite->setName(XML.getAttribute("sprite", "n", "", i));
                 sprite->setX(XML.getAttribute("sprite", "x", 0, i));
                 sprite->setY(XML.getAttribute("sprite", "y", 0, i));
                 sprite->setW(XML.getAttribute("sprite", "w", 0, i));
                 sprite->setH(XML.getAttribute("sprite", "h", 0, i));
-                sprite->setPX(XML.getAttribute("sprite", "pX", 0, i));
-                sprite->setPY(XML.getAttribute("sprite", "pY", 0, i));
+                sprite->setPX(XML.getAttribute("sprite", "pX", 0.0, i));
+                sprite->setPY(XML.getAttribute("sprite", "pY", 0.0, i));
                 sprite->setOffsetX(XML.getAttribute("sprite", "oX", 0, i));
                 sprite->setOffsetY(XML.getAttribute("sprite", "oY", 0, i));
                 sprite->setOffsetWidth(XML.getAttribute("sprite", "oW",  sprite->getW(), i));

--- a/src/ofxTPSprite.cpp
+++ b/src/ofxTPSprite.cpp
@@ -55,7 +55,11 @@ void ofxTPSprite::draw(int x, int y) {
         }
     }
     if(texture != NULL) {
+        ofPushMatrix();
+        //ofLog() << data->getPX() << " " << data->getW();
+        ofTranslate(-data->getPX() * data->getW(), -data->getPY() * data->getH());
         texture->drawSubsection(x, y, data->getW(), data->getH(), data->getX(), data->getY(), data->getW(), data->getH());
+        ofPopMatrix();
     }
     
     if(data->isRotated()) {


### PR DESCRIPTION
pivot wasn't being obeyed; now it works.

If you pivot is set to something other than UL corner, then don't use sprite trimmimg in TP when generating the sprite sheet.
